### PR TITLE
added the missing  styles for the backpack icon to fix large spacing …

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1463,6 +1463,8 @@ Parallax
   .philosophy_backpack_wrapper {
     display: flex;
     justify-content: center;
+    flex-direction: column;
+    align-items: center;
   }
 
   .philosophy_backpack_container {


### PR DESCRIPTION
…issue in safari.must've not copied during our zoom